### PR TITLE
refactor(hstr): avoid integer/pointer casts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,7 +368,7 @@ checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
 name = "hstr"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "compact_str",
  "criterion",

--- a/crates/hstr/Cargo.toml
+++ b/crates/hstr/Cargo.toml
@@ -5,7 +5,7 @@ edition     = "2021"
 license     = "Apache-2.0"
 name        = "hstr"
 repository  = "https://github.com/dudykr/ddbase.git"
-version     = "0.2.8"
+version     = "0.2.9"
 
 [lib]
 bench = false

--- a/crates/hstr/Cargo.toml
+++ b/crates/hstr/Cargo.toml
@@ -15,9 +15,10 @@ harness = false
 name    = "libs"
 
 [features]
-rkyv  = ["dep:rkyv"]
-serde = ["dep:serde"]
-
+rkyv          = ["dep:rkyv"]
+serde         = ["dep:serde"]
+atom_size_64  = []
+atom_size_128 = []
 
 [dependencies]
 hashbrown             = { version = "0.14.3", default-features = false }

--- a/crates/hstr/src/dynamic.rs
+++ b/crates/hstr/src/dynamic.rs
@@ -10,7 +10,10 @@ use std::{
 use rustc_hash::FxHasher;
 use triomphe::Arc;
 
-use crate::{tagged_value::{AtomicTaggedValue, TaggedValue, MAX_INLINE_LEN}, Atom, INLINE_TAG_INIT, LEN_OFFSET, TAG_MASK};
+use crate::{
+    tagged_value::{AtomicTaggedValue, TaggedValue, MAX_INLINE_LEN},
+    Atom, INLINE_TAG_INIT, LEN_OFFSET, TAG_MASK,
+};
 
 #[derive(Debug)]
 pub(crate) struct Entry {
@@ -104,10 +107,10 @@ where
         // INLINE_TAG ensures this is never zero
         let tag = INLINE_TAG_INIT | ((len as u8) << LEN_OFFSET);
         let mut unsafe_data = TaggedValue::new_tag(tag);
-        unsafe { unsafe_data.data_mut()[..len].copy_from_slice(text.as_bytes()); }
-        return Atom {
-            unsafe_data,
-        };
+        unsafe {
+            unsafe_data.data_mut()[..len].copy_from_slice(text.as_bytes());
+        }
+        return Atom { unsafe_data };
     }
 
     let hash = calc_hash(&text);
@@ -120,7 +123,7 @@ where
     };
     debug_assert!(0 == ptr.as_ptr() as u8 & TAG_MASK);
     Atom {
-        unsafe_data: TaggedValue::new_ptr(ptr)
+        unsafe_data: TaggedValue::new_ptr(ptr),
     }
 }
 

--- a/crates/hstr/src/dynamic.rs
+++ b/crates/hstr/src/dynamic.rs
@@ -2,35 +2,35 @@ use std::{
     borrow::Cow,
     fmt::Debug,
     hash::{BuildHasherDefault, Hash, Hasher},
-    num::{NonZeroU32, NonZeroU64},
+    num::NonZeroU32,
     ptr::NonNull,
-    sync::atomic::{AtomicU32, AtomicU64, Ordering::SeqCst},
+    sync::atomic::{AtomicU32, Ordering::SeqCst},
 };
 
 use rustc_hash::FxHasher;
 use triomphe::Arc;
 
-use crate::{inline_atom_slice_mut, Atom, INLINE_TAG, LEN_OFFSET, MAX_INLINE_LEN, TAG_MASK};
+use crate::{tagged_value::{AtomicTaggedValue, TaggedValue, MAX_INLINE_LEN}, Atom, INLINE_TAG_INIT, LEN_OFFSET, TAG_MASK};
 
 #[derive(Debug)]
 pub(crate) struct Entry {
     pub string: Box<str>,
     pub hash: u64,
     pub store_id: Option<NonZeroU32>,
-    pub alias: AtomicU64,
+    pub alias: AtomicTaggedValue,
 }
 
 impl Entry {
-    pub unsafe fn cast(ptr: NonZeroU64) -> *const Entry {
-        ptr.get() as *const Entry
+    pub unsafe fn cast(ptr: TaggedValue) -> *const Entry {
+        ptr.get_ptr().cast()
     }
 
-    pub unsafe fn deref_from<'i>(ptr: NonZeroU64) -> &'i Entry {
+    pub unsafe fn deref_from<'i>(ptr: TaggedValue) -> &'i Entry {
         &*Self::cast(ptr)
     }
 
-    pub unsafe fn restore_arc(v: NonZeroU64) -> Arc<Entry> {
-        let ptr = v.get() as *const Entry;
+    pub unsafe fn restore_arc(v: TaggedValue) -> Arc<Entry> {
+        let ptr = v.get_ptr() as *const Entry;
         Arc::from_raw(ptr)
     }
 }
@@ -82,7 +82,7 @@ impl AtomStore {
 
             let ptr = unsafe { NonNull::new_unchecked(Arc::as_ptr(&cur_entry) as *mut Entry) };
 
-            entry.alias.store(ptr.as_ptr() as u64, SeqCst);
+            entry.alias.store(TaggedValue::new_ptr(ptr), SeqCst);
         }
     }
 
@@ -101,14 +101,12 @@ where
     let len = text.len();
 
     if len < MAX_INLINE_LEN {
-        let mut data: u64 = (INLINE_TAG as u64) | ((len as u64) << LEN_OFFSET);
-        {
-            let dest = inline_atom_slice_mut(&mut data);
-            dest[..len].copy_from_slice(text.as_bytes())
-        }
+        // INLINE_TAG ensures this is never zero
+        let tag = INLINE_TAG_INIT | ((len as u8) << LEN_OFFSET);
+        let mut unsafe_data = TaggedValue::new_tag(tag);
+        unsafe { unsafe_data.data_mut()[..len].copy_from_slice(text.as_bytes()); }
         return Atom {
-            // INLINE_TAG ensures this is never zero
-            unsafe_data: unsafe { NonZeroU64::new_unchecked(data) },
+            unsafe_data,
         };
     }
 
@@ -120,11 +118,9 @@ where
         // Safety: Arc::into_raw returns a non-null pointer
         NonNull::new_unchecked(entry as *mut Entry)
     };
-    let data = ptr.as_ptr() as u64;
-
-    debug_assert!(0 == data & TAG_MASK);
+    debug_assert!(0 == ptr.as_ptr() as u8 & TAG_MASK);
     Atom {
-        unsafe_data: unsafe { NonZeroU64::new_unchecked(data) },
+        unsafe_data: TaggedValue::new_ptr(ptr)
     }
 }
 
@@ -146,7 +142,7 @@ impl Storage for &'_ mut AtomStore {
                         string: text.into_owned().into_boxed_str(),
                         hash,
                         store_id,
-                        alias: AtomicU64::new(0),
+                        alias: AtomicTaggedValue::default(),
                     }),
                     (),
                 )

--- a/crates/hstr/src/lib.rs
+++ b/crates/hstr/src/lib.rs
@@ -2,7 +2,12 @@
 //! See [Atom] for more information.
 
 use std::{
-    fmt::{Debug, Display}, hash::Hash, mem::{self, forget}, num::NonZeroU8, ops::Deref, sync::atomic::Ordering::SeqCst
+    fmt::{Debug, Display},
+    hash::Hash,
+    mem::{self, forget},
+    num::NonZeroU8,
+    ops::Deref,
+    sync::atomic::Ordering::SeqCst,
 };
 
 use debug_unreachable::debug_unreachable;

--- a/crates/hstr/src/lib.rs
+++ b/crates/hstr/src/lib.rs
@@ -1,23 +1,20 @@
+#![cfg_attr(feature = "atom_size_128", feature(integer_atomics))]
 //! See [Atom] for more information.
 
 use std::{
-    fmt::{Debug, Display},
-    hash::Hash,
-    mem::{self, forget},
-    num::NonZeroU64,
-    ops::Deref,
-    slice,
-    sync::atomic::Ordering::SeqCst,
+    fmt::{Debug, Display}, hash::Hash, mem::{self, forget}, num::NonZeroU8, ops::Deref, sync::atomic::Ordering::SeqCst
 };
 
 use debug_unreachable::debug_unreachable;
 use once_cell::sync::Lazy;
+use tagged_value::TaggedValue;
 
 pub use crate::dynamic::AtomStore;
 use crate::dynamic::Entry;
 
 mod dynamic;
 mod global_store;
+mod tagged_value;
 #[cfg(test)]
 mod tests;
 
@@ -51,9 +48,11 @@ mod tests;
 ///
 /// ```rust
 /// # use std::mem::size_of;
+/// # if !cfg!(feature = "atom_size_128") {
 /// use hstr::Atom;
 /// assert!(size_of::<Atom>() == size_of::<u64>());
 /// assert!(size_of::<Option<Atom>>() == size_of::<u64>());
+/// # }
 /// ````
 ///
 ///
@@ -87,7 +86,7 @@ mod tests;
 
 pub struct Atom {
     // If this Atom is a dynamic one, this is *const Entry
-    unsafe_data: NonZeroU64,
+    unsafe_data: TaggedValue,
 }
 
 #[doc(hidden)]
@@ -152,12 +151,12 @@ impl<'de> serde::de::Deserialize<'de> for Atom {
 }
 const DYNAMIC_TAG: u8 = 0b_00;
 const INLINE_TAG: u8 = 0b_01; // len in upper nybble
+const INLINE_TAG_INIT: NonZeroU8 = unsafe { NonZeroU8::new_unchecked(INLINE_TAG) };
 const STATIC_TAG: u8 = 0b_10;
-const TAG_MASK: u64 = 0b_11;
-const LEN_OFFSET: u64 = 4;
-const LEN_MASK: u64 = 0xf0;
+const TAG_MASK: u8 = 0b_11;
+const LEN_OFFSET: usize = 4;
+const LEN_MASK: u8 = 0xf0;
 
-const MAX_INLINE_LEN: usize = 7;
 // const STATIC_SHIFT_BITS: usize = 32;
 
 impl Atom {
@@ -171,7 +170,7 @@ impl Atom {
 
     #[inline(always)]
     fn tag(&self) -> u8 {
-        (self.unsafe_data.get() & TAG_MASK) as u8
+        self.unsafe_data.tag() & TAG_MASK
     }
 
     /// Return true if this is a dynamic Atom.
@@ -234,7 +233,7 @@ impl Atom {
             INLINE_TAG => {
                 // This is passed as input to the caller's `Hasher` implementation, so it's okay
                 // that this isn't really a hash
-                self.unsafe_data.get()
+                self.unsafe_data.hash()
             }
             _ => unsafe { debug_unreachable!() },
         }
@@ -248,8 +247,8 @@ impl Atom {
                 todo!("static as_str")
             }
             INLINE_TAG => {
-                let len = (self.unsafe_data.get() & LEN_MASK) >> LEN_OFFSET;
-                let src = inline_atom_slice(&self.unsafe_data);
+                let len = (self.unsafe_data.tag() & LEN_MASK) >> LEN_OFFSET;
+                let src = self.unsafe_data.data();
                 unsafe { std::str::from_utf8_unchecked(&src[..(len as usize)]) }
             }
             _ => unsafe { debug_unreachable!() },
@@ -281,7 +280,7 @@ impl Atom {
             // This is slow, but we don't reach here in most cases
             let te = unsafe { Entry::deref_from(self.unsafe_data) };
 
-            if let Some(self_alias) = NonZeroU64::new(te.alias.load(SeqCst)) {
+            if let Some(self_alias) = te.alias.load(SeqCst) {
                 if let Some(result) = other.simple_eq(&Atom::from_alias(self_alias)) {
                     return Some(result);
                 }
@@ -290,7 +289,7 @@ impl Atom {
 
         if other.is_dynamic() {
             let oe = unsafe { Entry::deref_from(other.unsafe_data) };
-            if let Some(other_alias) = NonZeroU64::new(oe.alias.load(SeqCst)) {
+            if let Some(other_alias) = oe.alias.load(SeqCst) {
                 if let Some(result) = self.simple_eq(&Atom::from_alias(other_alias)) {
                     return Some(result);
                 }
@@ -359,8 +358,8 @@ impl Clone for Atom {
 
 impl Atom {
     #[inline]
-    pub(crate) fn from_alias(alias: NonZeroU64) -> Self {
-        if (alias.get() & TAG_MASK) as u8 == DYNAMIC_TAG {
+    pub(crate) fn from_alias(alias: TaggedValue) -> Self {
+        if alias.tag() & TAG_MASK == DYNAMIC_TAG {
             unsafe {
                 let arc = Entry::restore_arc(alias);
                 forget(arc.clone());
@@ -439,35 +438,5 @@ where
         let s: String = self.deserialize(deserializer)?;
 
         Ok(Atom::new(s))
-    }
-}
-
-#[inline(always)]
-fn inline_atom_slice(x: &NonZeroU64) -> &[u8] {
-    unsafe {
-        let x: *const NonZeroU64 = x;
-        let mut data = x as *const u8;
-        // All except the lowest byte, which is first in little-endian, last in
-        // big-endian.
-        if cfg!(target_endian = "little") {
-            data = data.offset(1);
-        }
-        let len = 7;
-        slice::from_raw_parts(data, len)
-    }
-}
-
-#[inline(always)]
-fn inline_atom_slice_mut(x: &mut u64) -> &mut [u8] {
-    unsafe {
-        let x: *mut u64 = x;
-        let mut data = x as *mut u8;
-        // All except the lowest byte, which is first in little-endian, last in
-        // big-endian.
-        if cfg!(target_endian = "little") {
-            data = data.offset(1);
-        }
-        let len = 7;
-        slice::from_raw_parts_mut(data, len)
     }
 }

--- a/crates/hstr/src/tagged_value.rs
+++ b/crates/hstr/src/tagged_value.rs
@@ -2,16 +2,34 @@ use std::{num::NonZeroU8, os::raw::c_void, ptr::NonNull, slice};
 
 #[cfg(feature = "atom_size_128")]
 type RawTaggedValue = u128;
-#[cfg(any(target_pointer_width = "32", target_pointer_width = "16", feature = "atom_size_64"))]
+#[cfg(any(
+    target_pointer_width = "32",
+    target_pointer_width = "16",
+    feature = "atom_size_64"
+))]
 type RawTaggedValue = u64;
-#[cfg(not(any(target_pointer_width = "32", target_pointer_width = "16", feature = "atom_size_64", feature = "atom_size_128")))]
+#[cfg(not(any(
+    target_pointer_width = "32",
+    target_pointer_width = "16",
+    feature = "atom_size_64",
+    feature = "atom_size_128"
+)))]
 type RawTaggedValue = usize;
 
 #[cfg(feature = "atom_size_128")]
 type RawTaggedNonZeroValue = std::num::NonZeroU128;
-#[cfg(any(target_pointer_width = "32", target_pointer_width = "16", feature = "atom_size_64"))]
+#[cfg(any(
+    target_pointer_width = "32",
+    target_pointer_width = "16",
+    feature = "atom_size_64"
+))]
 type RawTaggedNonZeroValue = std::num::NonZeroU64;
-#[cfg(not(any(target_pointer_width = "32", target_pointer_width = "16", feature = "atom_size_64", feature = "atom_size_128")))]
+#[cfg(not(any(
+    target_pointer_width = "32",
+    target_pointer_width = "16",
+    feature = "atom_size_64",
+    feature = "atom_size_128"
+)))]
 type RawTaggedNonZeroValue = std::ptr::NonNull<()>;
 
 pub(crate) const MAX_INLINE_LEN: usize = std::mem::size_of::<TaggedValue>() - 1;
@@ -25,22 +43,38 @@ pub(crate) struct TaggedValue {
 impl TaggedValue {
     #[inline(always)]
     pub fn new_ptr<T>(value: NonNull<T>) -> Self {
-        #[cfg(any(target_pointer_width = "32", target_pointer_width = "16", feature = "atom_size_64", feature = "atom_size_128"))]
-        unsafe { 
+        #[cfg(any(
+            target_pointer_width = "32",
+            target_pointer_width = "16",
+            feature = "atom_size_64",
+            feature = "atom_size_128"
+        ))]
+        unsafe {
             let value: std::num::NonZeroUsize = std::mem::transmute(value);
-            Self { value: RawTaggedNonZeroValue::new_unchecked(value.get() as _) } 
+            Self {
+                value: RawTaggedNonZeroValue::new_unchecked(value.get() as _),
+            }
         }
 
-        #[cfg(not(any(target_pointer_width = "32", target_pointer_width = "16", feature = "atom_size_64", feature = "atom_size_128")))]
-        { 
-            Self { value: value.cast() } 
+        #[cfg(not(any(
+            target_pointer_width = "32",
+            target_pointer_width = "16",
+            feature = "atom_size_64",
+            feature = "atom_size_128"
+        )))]
+        {
+            Self {
+                value: value.cast(),
+            }
         }
     }
 
     #[inline(always)]
     pub fn new_tag(value: NonZeroU8) -> Self {
         let value = value.get() as RawTaggedValue;
-        Self { value: unsafe { std::mem::transmute(value) } }
+        Self {
+            value: unsafe { std::mem::transmute(value) },
+        }
     }
 
     #[inline(always)]
@@ -50,10 +84,24 @@ impl TaggedValue {
 
     #[inline(always)]
     pub fn get_ptr(&self) -> *const c_void {
-        #[cfg(any(target_pointer_width = "32", target_pointer_width = "16", feature = "atom_size_64", feature = "atom_size_128"))]
-        { self.value.get() as usize as _ }
-        #[cfg(not(any(target_pointer_width = "32", target_pointer_width = "16", feature = "atom_size_64", feature = "atom_size_128")))]
-        unsafe { std::mem::transmute(Some(self.value)) }
+        #[cfg(any(
+            target_pointer_width = "32",
+            target_pointer_width = "16",
+            feature = "atom_size_64",
+            feature = "atom_size_128"
+        ))]
+        {
+            self.value.get() as usize as _
+        }
+        #[cfg(not(any(
+            target_pointer_width = "32",
+            target_pointer_width = "16",
+            feature = "atom_size_64",
+            feature = "atom_size_128"
+        )))]
+        unsafe {
+            std::mem::transmute(Some(self.value))
+        }
     }
 
     #[inline(always)]
@@ -72,15 +120,18 @@ impl TaggedValue {
         // All except the lowest byte, which is first in little-endian, last in
         // big-endian.
         if cfg!(target_endian = "little") {
-            unsafe { data = data.offset(1); }
+            unsafe {
+                data = data.offset(1);
+            }
         }
         let len = std::mem::size_of::<TaggedValue>() - 1;
         unsafe { slice::from_raw_parts(data, len) }
     }
-    
-    /// The `TaggedValue` is a non-zero number or pointer, so caution must be used when setting
-    /// the untagged slice part of this value. If tag is zero and the slice is zeroed out, using
-    /// this `TaggedValue` will be UB!
+
+    /// The `TaggedValue` is a non-zero number or pointer, so caution must be
+    /// used when setting the untagged slice part of this value. If tag is
+    /// zero and the slice is zeroed out, using this `TaggedValue` will be
+    /// UB!
     pub unsafe fn data_mut(&mut self) -> &mut [u8] {
         let x: *mut _ = &mut self.value;
         let mut data = x as *mut u8;
@@ -99,20 +150,32 @@ impl TaggedValue {
 pub(crate) struct AtomicTaggedValue {
     #[cfg(feature = "atom_size_128")]
     value: std::sync::atomic::AtomicU128,
-    #[cfg(any(target_pointer_width = "32", target_pointer_width = "16", feature = "atom_size_64"))]
+    #[cfg(any(
+        target_pointer_width = "32",
+        target_pointer_width = "16",
+        feature = "atom_size_64"
+    ))]
     value: std::sync::atomic::AtomicU64,
-    #[cfg(not(any(target_pointer_width = "32", target_pointer_width = "16", feature = "atom_size_64", feature = "atom_size_128")))]
+    #[cfg(not(any(
+        target_pointer_width = "32",
+        target_pointer_width = "16",
+        feature = "atom_size_64",
+        feature = "atom_size_128"
+    )))]
     value: std::sync::atomic::AtomicPtr<()>,
 }
 
 impl AtomicTaggedValue {
     pub fn load(&self, ordering: std::sync::atomic::Ordering) -> Option<TaggedValue> {
-        // The niche guarantees that Option<TaggedValue> has the same layout as the atomic
+        // The niche guarantees that Option<TaggedValue> has the same layout as the
+        // atomic
         unsafe { std::mem::transmute(self.value.load(ordering)) }
     }
+
     pub fn store(&self, value: TaggedValue, ordering: std::sync::atomic::Ordering) {
         let value = Some(value);
-        // The niche guarantees that Option<TaggedValue> has the same layout as the atomic
+        // The niche guarantees that Option<TaggedValue> has the same layout as the
+        // atomic
         unsafe { self.value.store(std::mem::transmute(value), ordering) }
     }
 }

--- a/crates/hstr/src/tagged_value.rs
+++ b/crates/hstr/src/tagged_value.rs
@@ -1,0 +1,118 @@
+use std::{num::NonZeroU8, os::raw::c_void, ptr::NonNull, slice};
+
+#[cfg(feature = "atom_size_128")]
+type RawTaggedValue = u128;
+#[cfg(any(target_pointer_width = "32", target_pointer_width = "16", feature = "atom_size_64"))]
+type RawTaggedValue = u64;
+#[cfg(not(any(target_pointer_width = "32", target_pointer_width = "16", feature = "atom_size_64", feature = "atom_size_128")))]
+type RawTaggedValue = usize;
+
+#[cfg(feature = "atom_size_128")]
+type RawTaggedNonZeroValue = std::num::NonZeroU128;
+#[cfg(any(target_pointer_width = "32", target_pointer_width = "16", feature = "atom_size_64"))]
+type RawTaggedNonZeroValue = std::num::NonZeroU64;
+#[cfg(not(any(target_pointer_width = "32", target_pointer_width = "16", feature = "atom_size_64", feature = "atom_size_128")))]
+type RawTaggedNonZeroValue = std::ptr::NonNull<()>;
+
+pub(crate) const MAX_INLINE_LEN: usize = std::mem::size_of::<TaggedValue>() - 1;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[repr(transparent)]
+pub(crate) struct TaggedValue {
+    value: RawTaggedNonZeroValue,
+}
+
+impl TaggedValue {
+    #[inline(always)]
+    pub fn new_ptr<T>(value: NonNull<T>) -> Self {
+        #[cfg(any(target_pointer_width = "32", target_pointer_width = "16", feature = "atom_size_64", feature = "atom_size_128"))]
+        unsafe { 
+            let value: std::num::NonZeroUsize = std::mem::transmute(value);
+            Self { value: RawTaggedNonZeroValue::new_unchecked(value.get() as _) } 
+        }
+
+        #[cfg(not(any(target_pointer_width = "32", target_pointer_width = "16", feature = "atom_size_64", feature = "atom_size_128")))]
+        { 
+            Self { value: value.cast() } 
+        }
+    }
+
+    #[inline(always)]
+    pub fn new_tag(value: NonZeroU8) -> Self {
+        let value = value.get() as RawTaggedValue;
+        Self { value: unsafe { std::mem::transmute(value) } }
+    }
+
+    #[inline(always)]
+    pub fn hash(&self) -> u64 {
+        self.get_value() as _
+    }
+
+    #[inline(always)]
+    pub fn get_ptr(&self) -> *const c_void {
+        #[cfg(any(target_pointer_width = "32", target_pointer_width = "16", feature = "atom_size_64", feature = "atom_size_128"))]
+        { self.value.get() as usize as _ }
+        #[cfg(not(any(target_pointer_width = "32", target_pointer_width = "16", feature = "atom_size_64", feature = "atom_size_128")))]
+        unsafe { std::mem::transmute(Some(self.value)) }
+    }
+
+    #[inline(always)]
+    fn get_value(&self) -> RawTaggedValue {
+        unsafe { std::mem::transmute(Some(self.value)) }
+    }
+
+    #[inline(always)]
+    pub fn tag(&self) -> u8 {
+        (self.get_value() & 0xff) as u8
+    }
+
+    pub fn data(&self) -> &[u8] {
+        let x: *const _ = &self.value;
+        let mut data = x as *const u8;
+        // All except the lowest byte, which is first in little-endian, last in
+        // big-endian.
+        if cfg!(target_endian = "little") {
+            unsafe { data = data.offset(1); }
+        }
+        let len = std::mem::size_of::<TaggedValue>() - 1;
+        unsafe { slice::from_raw_parts(data, len) }
+    }
+    
+    /// The `TaggedValue` is a non-zero number or pointer, so caution must be used when setting
+    /// the untagged slice part of this value. If tag is zero and the slice is zeroed out, using
+    /// this `TaggedValue` will be UB!
+    pub unsafe fn data_mut(&mut self) -> &mut [u8] {
+        let x: *mut _ = &mut self.value;
+        let mut data = x as *mut u8;
+        // All except the lowest byte, which is first in little-endian, last in
+        // big-endian.
+        if cfg!(target_endian = "little") {
+            data = data.offset(1);
+        }
+        let len = std::mem::size_of::<TaggedValue>() - 1;
+        slice::from_raw_parts_mut(data, len)
+    }
+}
+
+#[derive(Debug, Default)]
+#[repr(transparent)]
+pub(crate) struct AtomicTaggedValue {
+    #[cfg(feature = "atom_size_128")]
+    value: std::sync::atomic::AtomicU128,
+    #[cfg(any(target_pointer_width = "32", target_pointer_width = "16", feature = "atom_size_64"))]
+    value: std::sync::atomic::AtomicU64,
+    #[cfg(not(any(target_pointer_width = "32", target_pointer_width = "16", feature = "atom_size_64", feature = "atom_size_128")))]
+    value: std::sync::atomic::AtomicPtr<()>,
+}
+
+impl AtomicTaggedValue {
+    pub fn load(&self, ordering: std::sync::atomic::Ordering) -> Option<TaggedValue> {
+        // The niche guarantees that Option<TaggedValue> has the same layout as the atomic
+        unsafe { std::mem::transmute(self.value.load(ordering)) }
+    }
+    pub fn store(&self, value: TaggedValue, ordering: std::sync::atomic::Ordering) {
+        let value = Some(value);
+        // The niche guarantees that Option<TaggedValue> has the same layout as the atomic
+        unsafe { self.value.store(std::mem::transmute(value), ordering) }
+    }
+}

--- a/crates/hstr/src/tests.rs
+++ b/crates/hstr/src/tests.rs
@@ -23,8 +23,8 @@ fn simple_usage() {
 
 #[test]
 fn eager_drop() {
-    let (_, atoms1) = store_with_atoms(vec!["Hello, world!"]);
-    let (_, atoms2) = store_with_atoms(vec!["Hello, world!"]);
+    let (_, atoms1) = store_with_atoms(vec!["Hello, world!!!!"]);
+    let (_, atoms2) = store_with_atoms(vec!["Hello, world!!!!"]);
 
     dbg!(&atoms1);
     dbg!(&atoms2);
@@ -42,8 +42,8 @@ fn eager_drop() {
 
 #[test]
 fn store_multiple() {
-    let (_s1, atoms1) = store_with_atoms(vec!["Hello, world!"]);
-    let (_s2, atoms2) = store_with_atoms(vec!["Hello, world!"]);
+    let (_s1, atoms1) = store_with_atoms(vec!["Hello, world!!!!"]);
+    let (_s2, atoms2) = store_with_atoms(vec!["Hello, world!!!!"]);
 
     let a1 = atoms1[0].clone();
     let a2 = atoms2[0].clone();
@@ -58,8 +58,8 @@ fn store_multiple() {
 
 #[test]
 fn store_merge_two() {
-    let (mut s1, atoms1) = store_with_atoms(vec!["Hello, world!"]);
-    let (s2, atoms2) = store_with_atoms(vec!["Hello, world!"]);
+    let (mut s1, atoms1) = store_with_atoms(vec!["Hello, world!!!!"]);
+    let (s2, atoms2) = store_with_atoms(vec!["Hello, world!!!!"]);
 
     let a1 = atoms1[0].clone();
     let a2 = atoms2[0].clone();
@@ -68,7 +68,7 @@ fn store_merge_two() {
 
     s1.merge(s2);
 
-    let a3 = s1.atom("Hello, world!");
+    let a3 = s1.atom("Hello, world!!!!");
 
     assert_eq!(
         a1.unsafe_data, a3.unsafe_data,
@@ -90,8 +90,8 @@ fn store_merge_two() {
 
 #[test]
 fn store_merge_many_1() {
-    let (mut s1, atoms1) = store_with_atoms(vec!["Hello, world!"]);
-    let (s2, atoms2) = store_with_atoms(vec!["Hello, world!"]);
+    let (mut s1, atoms1) = store_with_atoms(vec!["Hello, world!!!!"]);
+    let (s2, atoms2) = store_with_atoms(vec!["Hello, world!!!!"]);
     let (s3, atoms3) = store_with_atoms(vec!["Hi!"]);
 
     let a1 = atoms1[0].clone();
@@ -108,7 +108,7 @@ fn store_merge_many_1() {
     s1.merge(s2);
     s1.merge(s3);
 
-    let a4 = s1.atom("Hello, world!");
+    let a4 = s1.atom("Hello, world!!!!");
 
     assert_eq!(
         a1.unsafe_data, a4.unsafe_data,


### PR DESCRIPTION
Fixes https://github.com/dudykr/ddbase/issues/30

If we're running on a platform where pointer sizes are `u64`, avoids using integer/pointer casts to ensure that we can safely keep pointer provenance and allow Miri to better check for pointer bugs.

On 32-bit platforms, or if the feature `atom_size_64` is passed, it uses a 64-bit sized atom. 

I've also added `atom_size_128` to help test that everything will work on platforms with even wider pointers, but that functionality could easily be stripped out and will shrink this PR quite a bit.

After patch:

```
$ cargo +nightly miri test -p hstr
Preparing a sysroot for Miri (target: aarch64-apple-darwin)... done
    Finished test [unoptimized + debuginfo] target(s) in 0.06s
     Running unittests src/lib.rs (target/miri/aarch64-apple-darwin/debug/deps/hstr-c73471a494f7bbaf)

running 5 tests
test tests::eager_drop ... ok
test tests::simple_usage ... ok
test tests::store_merge_many_1 ... ok
test tests::store_merge_two ... ok
test tests::store_multiple ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

   Doc-tests hstr

running 1 test
test crates/hstr/src/lib.rs - Atom (line 49) ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.08s
```


Before patch:

```
test tests::eager_drop ... warning: integer-to-pointer cast
   --> crates/hstr/src/dynamic.rs:25:9
    |
25  |         ptr.get() as *const Entry
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^ integer-to-pointer cast
    |
    = help: This program is using integer-to-pointer casts or (equivalently) `ptr::from_exposed_addr`,
    = help: which means that Miri might miss pointer bugs in this program.
    = help: See https://doc.rust-lang.org/nightly/std/ptr/fn.from_exposed_addr.html for more details on that operation.
    = help: To ensure that Miri does not miss bugs in your program, use Strict Provenance APIs (https://doc.rust-lang.org/nightly/std/ptr/index.html#strict-provenance, https://crates.io/crates/sptr) instead.
```