### PR TITLE
fix(hstr): ensure refcounts are kept during store merges

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,7 +368,7 @@ checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
 name = "hstr"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "compact_str",
  "criterion",

--- a/crates/hstr/Cargo.toml
+++ b/crates/hstr/Cargo.toml
@@ -5,7 +5,7 @@ edition     = "2021"
 license     = "Apache-2.0"
 name        = "hstr"
 repository  = "https://github.com/dudykr/ddbase.git"
-version     = "0.2.9"
+version     = "0.2.10"
 
 [lib]
 bench = false

--- a/crates/hstr/src/lib.rs
+++ b/crates/hstr/src/lib.rs
@@ -260,6 +260,15 @@ impl Atom {
         }
     }
 
+    #[cfg(test)]
+    fn ref_count(&self) -> usize {
+        if self.tag() == DYNAMIC_TAG {
+            unsafe { Entry::ref_count(self.unsafe_data) }
+        } else {
+            0
+        }
+    }
+
     #[inline(always)]
     fn simple_eq(&self, other: &Self) -> Option<bool> {
         if self.unsafe_data == other.unsafe_data {

--- a/crates/hstr/src/tagged_value.rs
+++ b/crates/hstr/src/tagged_value.rs
@@ -172,10 +172,15 @@ impl AtomicTaggedValue {
         unsafe { std::mem::transmute(self.value.load(ordering)) }
     }
 
-    pub fn store(&self, value: TaggedValue, ordering: std::sync::atomic::Ordering) {
+    #[must_use]
+    pub fn swap(
+        &self,
+        value: TaggedValue,
+        ordering: std::sync::atomic::Ordering,
+    ) -> Option<TaggedValue> {
         let value = Some(value);
         // The niche guarantees that Option<TaggedValue> has the same layout as the
         // atomic
-        unsafe { self.value.store(std::mem::transmute(value), ordering) }
+        unsafe { std::mem::transmute(self.value.swap(std::mem::transmute(value), ordering)) }
     }
 }

--- a/crates/hstr/src/tests.rs
+++ b/crates/hstr/src/tests.rs
@@ -22,6 +22,35 @@ fn simple_usage() {
 }
 
 #[test]
+fn store_merge_and_drop() {
+    let (mut s1, atoms1) = store_with_atoms(vec!["Hello, world!!!!"]);
+    let a1 = atoms1.into_iter().next().unwrap();
+    assert_eq!(2, a1.ref_count());
+    let (mut s2, atoms2) = store_with_atoms(vec!["Hello, world!!!!"]);
+    let a2 = atoms2.into_iter().next().unwrap();
+    let (s3, atoms3) = store_with_atoms(vec!["Hello, world!!!!"]);
+    let a3 = atoms3.into_iter().next().unwrap();
+    s2.merge(s3);
+    assert_eq!(2, a1.ref_count());
+    s1.merge(s2);
+    assert_eq!(3, a1.ref_count());
+
+    assert_eq!("Hello, world!!!!", a1.as_str());
+    assert_eq!("Hello, world!!!!", a2.as_str());
+    assert_eq!("Hello, world!!!!", a3.as_str());
+
+    drop(s1);
+    assert_eq!(2, a1.ref_count());
+
+    assert_eq!("Hello, world!!!!", a1.as_str());
+    assert_eq!(a1, a2);
+    drop(a1);
+    assert_eq!(a2, a3);
+    assert_eq!("Hello, world!!!!", a2.as_str());
+    assert_eq!("Hello, world!!!!", a3.as_str());
+}
+
+#[test]
 fn eager_drop() {
     let (_, atoms1) = store_with_atoms(vec!["Hello, world!!!!"]);
     let (_, atoms2) = store_with_atoms(vec!["Hello, world!!!!"]);


### PR DESCRIPTION
The alias field update process in store merging didn't modify the refcount of the aliased entry. This could cause a dangling pointer to be followed when checking atom equality.

The simplest fix here is to ensure that entry aliases always increase the refcount of the aliased entry, and that they drop the refcount when they are dropped.

```
test tests::store_merge_and_drop ... error: Undefined Behavior: out-of-bounds pointer arithmetic: alloc41171 has been freed, so this pointer is dangling
   --> /Users/matt/.cargo/registry/src/index.crates.io-6f17d22bba15001f/triomphe-0.1.11/src/arc.rs:90:19
    |
90  |         let ptr = (ptr as *const u8).sub(offset_of!(ArcInner<T>, data));
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ out-of-bounds pointer arithmetic: alloc41171 has been freed, so this pointer is dangling
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
help: alloc41171 was allocated here:
   --> crates/hstr/src/dynamic.rs:155:21
    |
155 | /                     Arc::new(Entry {
156 | |                         string: text.into_owned().into_boxed_str(),
157 | |                         hash,
158 | |                         store_id,
159 | |                         alias: AtomicTaggedValue::default(),
160 | |                     }),
    | |______________________^
help: alloc41171 was deallocated here:
   --> crates/hstr/src/lib.rs:361:22
    |
361 |             unsafe { drop(Entry::restore_arc(self.unsafe_data)) }
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `triomphe::Arc::<dynamic::Entry>::from_raw` at /Users/matt/.cargo/registry/src/index.crates.io-6f17d22bba15001f/triomphe-0.1.11/src/arc.rs:90:19: 90:72
note: inside `dynamic::Entry::restore_arc`
   --> crates/hstr/src/dynamic.rs:45:9
    |
45  |         Arc::from_raw(ptr)
    |         ^^^^^^^^^^^^^^^^^^
note: inside `Atom::from_alias`
   --> crates/hstr/src/lib.rs:378:27
    |
378 |                 let arc = Entry::restore_arc(alias);
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^
note: inside `Atom::simple_eq_slow`
   --> crates/hstr/src/lib.rs:298:56
    |
298 |                 if let Some(result) = other.simple_eq(&Atom::from_alias(self_alias)) {
    |                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: inside `Atom::simple_eq`
   --> crates/hstr/src/lib.rs:288:9
    |
288 |         self.simple_eq_slow(other)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
note: inside `<Atom as std::cmp::PartialEq>::eq`
   --> crates/hstr/src/lib.rs:320:31
    |
320 |         if let Some(result) = self.simple_eq(other) {
    |                               ^^^^^^^^^^^^^^^^^^^^^
note: inside `tests::store_merge_and_drop`
   --> crates/hstr/src/tests.rs:44:5
    |
44  |     assert_eq!(a2, a3);
```