### PR TITLE
refactor(par_core): simplify `join`

### DIFF
--- a/crates/par-core/src/lib.rs
+++ b/crates/par-core/src/lib.rs
@@ -72,7 +72,6 @@ mod par_chili {
 
     enum ScopeLike<'a> {
         Scope(Scope<'a>),
-        #[cfg(feature = "chili")]
         Global(Option<chili::Scope<'a>>),
     }
 
@@ -88,7 +87,6 @@ mod par_chili {
         where
             F: FnOnce(Scope<'a>) -> R,
         {
-            #[cfg(feature = "chili")]
             let scope: &mut chili::Scope = match &mut self.0 {
                 ScopeLike::Scope(scope) => unsafe {
                     // Safety: chili Scope will be alive until the end of the function, because it's
@@ -96,7 +94,6 @@ mod par_chili {
 
                     transmute::<&mut chili::Scope, &mut chili::Scope>(&mut scope.0)
                 },
-                #[cfg(feature = "chili")]
                 ScopeLike::Global(global_scope) => {
                     // Initialize global scope lazily, and only once.
                     let scope = global_scope.get_or_insert_with(|| chili::Scope::global());
@@ -110,7 +107,6 @@ mod par_chili {
                 }
             };
 
-            #[cfg(feature = "chili")]
             let scope = Scope(scope);
 
             f(scope)
@@ -140,7 +136,6 @@ mod par_chili {
         RA: Send,
         RB: Send,
     {
-        #[cfg(feature = "chili")]
         let (ra, rb) = scope.0.join(
             |scope| {
                 let scope = Scope(unsafe {

--- a/crates/par-core/src/lib.rs
+++ b/crates/par-core/src/lib.rs
@@ -51,88 +51,169 @@
 //! par-core = { version = "1.0.1", default-features = false }
 //! ```
 
-#![cfg_attr(not(feature = "chili"), allow(unused_variables))]
-
-use std::{cell::RefCell, mem::transmute};
-
 #[cfg(all(not(feature = "chili"), not(feature = "rayon"), feature = "parallel"))]
 compile_error!("You must enable `chili` or `rayon` feature if you want to use `parallel` feature");
 
 #[cfg(all(feature = "chili", feature = "rayon"))]
 compile_error!("You must enable `chili` or `rayon` feature, not both");
 
-#[derive(Default)]
-pub struct MaybeScope<'a>(ScopeLike<'a>);
+#[cfg(feature = "chili")]
+mod par_chili {
+    use std::{cell::RefCell, mem::transmute};
 
-enum ScopeLike<'a> {
-    Scope(Scope<'a>),
-    #[cfg(feature = "chili")]
-    Global(Option<chili::Scope<'a>>),
-}
+    thread_local! {
+        static SCOPE: RefCell<Option<MaybeScope<'static>>> = Default::default();
+    }
 
-impl Default for ScopeLike<'_> {
-    fn default() -> Self {
+    #[derive(Default)]
+    pub struct MaybeScope<'a>(ScopeLike<'a>);
+
+    pub struct Scope<'a>(&'a mut chili::Scope<'a>);
+
+    enum ScopeLike<'a> {
+        Scope(Scope<'a>),
         #[cfg(feature = "chili")]
-        {
+        Global(Option<chili::Scope<'a>>),
+    }
+
+    impl Default for ScopeLike<'_> {
+        fn default() -> Self {
             ScopeLike::Global(None)
         }
+    }
 
-        #[cfg(not(feature = "chili"))]
+    impl<'a> MaybeScope<'a> {
+        #[allow(clippy::redundant_closure)]
+        pub fn with<F, R>(&mut self, f: F) -> R
+        where
+            F: FnOnce(Scope<'a>) -> R,
         {
-            ScopeLike::Scope(Scope(std::marker::PhantomData))
+            #[cfg(feature = "chili")]
+            let scope: &mut chili::Scope = match &mut self.0 {
+                ScopeLike::Scope(scope) => unsafe {
+                    // Safety: chili Scope will be alive until the end of the function, because it's
+                    // contract of 'a lifetime in the type.
+
+                    transmute::<&mut chili::Scope, &mut chili::Scope>(&mut scope.0)
+                },
+                #[cfg(feature = "chili")]
+                ScopeLike::Global(global_scope) => {
+                    // Initialize global scope lazily, and only once.
+                    let scope = global_scope.get_or_insert_with(|| chili::Scope::global());
+
+                    unsafe {
+                        // Safety: Global scope is not dropped until the end of the program, and no
+                        // one can access this **instance** of the global
+                        // scope in the same time.
+                        transmute::<&mut chili::Scope, &mut chili::Scope>(scope)
+                    }
+                }
+            };
+
+            #[cfg(feature = "chili")]
+            let scope = Scope(scope);
+
+            f(scope)
         }
     }
-}
 
-impl<'a> From<Scope<'a>> for MaybeScope<'a> {
-    fn from(value: Scope<'a>) -> Self {
-        MaybeScope(ScopeLike::Scope(value))
-    }
-}
-
-impl<'a> MaybeScope<'a> {
-    #[allow(clippy::redundant_closure)]
-    pub fn with<F, R>(&mut self, f: F) -> R
+    #[inline]
+    pub fn join_maybe_scoped<'a, A, B, RA, RB>(
+        scope: &mut MaybeScope<'a>,
+        oper_a: A,
+        oper_b: B,
+    ) -> (RA, RB)
     where
-        F: FnOnce(Scope<'a>) -> R,
+        A: Send + FnOnce(Scope<'a>) -> RA,
+        B: Send + FnOnce(Scope<'a>) -> RB,
+        RA: Send,
+        RB: Send,
+    {
+        scope.with(|scope| join_scoped(scope, oper_a, oper_b))
+    }
+
+    #[inline]
+    pub fn join_scoped<'a, A, B, RA, RB>(scope: Scope<'a>, oper_a: A, oper_b: B) -> (RA, RB)
+    where
+        A: Send + FnOnce(Scope<'a>) -> RA,
+        B: Send + FnOnce(Scope<'a>) -> RB,
+        RA: Send,
+        RB: Send,
     {
         #[cfg(feature = "chili")]
-        let scope: &mut chili::Scope = match &mut self.0 {
-            ScopeLike::Scope(scope) => unsafe {
-                // Safety: chili Scope will be alive until the end of the function, because it's
-                // contract of 'a lifetime in the type.
-                transmute::<&mut chili::Scope, &mut chili::Scope>(&mut scope.0)
-            },
-            #[cfg(feature = "chili")]
-            ScopeLike::Global(global_scope) => {
-                // Initialize global scope lazily, and only once.
-                let scope = global_scope.get_or_insert_with(|| chili::Scope::global());
-
-                unsafe {
-                    // Safety: Global scope is not dropped until the end of the program, and no one
-                    // can access this **instance** of the global scope in the same time.
+        let (ra, rb) = scope.0.join(
+            |scope| {
+                let scope = Scope(unsafe {
+                    // Safety: This can be dangerous if the user do transmute on the scope, but it's
+                    // not our fault if the user uses transmute.
                     transmute::<&mut chili::Scope, &mut chili::Scope>(scope)
-                }
+                });
+
+                oper_a(scope)
+            },
+            |scope| {
+                let scope = Scope(unsafe {
+                    // Safety: This can be dangerous if the user do transmute on the scope, but it's
+                    // not our fault if the user uses transmute.
+                    transmute::<&mut chili::Scope, &mut chili::Scope>(scope)
+                });
+
+                oper_b(scope)
+            },
+        );
+
+        (ra, rb)
+    }
+
+    #[inline]
+    pub fn join<A, B, RA, RB>(oper_a: A, oper_b: B) -> (RA, RB)
+    where
+        A: Send + FnOnce() -> RA,
+        B: Send + FnOnce() -> RB,
+        RA: Send,
+        RB: Send,
+    {
+        struct RemoveScopeGuard;
+
+        impl Drop for RemoveScopeGuard {
+            fn drop(&mut self) {
+                SCOPE.set(None);
             }
-        };
+        }
 
-        #[cfg(feature = "chili")]
-        let scope = Scope(scope);
+        let mut scope = SCOPE.take().unwrap_or_default();
 
-        #[cfg(not(feature = "chili"))]
-        let scope = Scope(std::marker::PhantomData);
+        let (ra, rb) = join_maybe_scoped(
+            &mut scope,
+            |scope| {
+                let scope = unsafe {
+                    // Safety: inner scope cannot outlive the outer scope
+                    transmute::<Scope, Scope>(scope)
+                };
+                let _guard = RemoveScopeGuard;
+                SCOPE.set(Some(MaybeScope(ScopeLike::Scope(scope))));
 
-        f(scope)
+                oper_a()
+            },
+            |scope| {
+                let scope = unsafe {
+                    // Safety: inner scope cannot outlive the outer scope
+                    transmute::<Scope, Scope>(scope)
+                };
+                let _guard = RemoveScopeGuard;
+                SCOPE.set(Some(MaybeScope(ScopeLike::Scope(scope))));
+
+                oper_b()
+            },
+        );
+
+        // In case of panic, we does not restore the scope so it will be None.
+        SCOPE.set(Some(scope));
+
+        (ra, rb)
     }
 }
 
-#[cfg(not(feature = "chili"))]
-pub struct Scope<'a>(std::marker::PhantomData<&'a mut &'a ()>);
-
-#[cfg(feature = "chili")]
-pub struct Scope<'a>(&'a mut chili::Scope<'a>);
-
-#[inline]
 pub fn join<A, B, RA, RB>(oper_a: A, oper_b: B) -> (RA, RB)
 where
     A: Send + FnOnce() -> RA,
@@ -140,106 +221,14 @@ where
     RA: Send,
     RB: Send,
 {
-    thread_local! {
-        static SCOPE: RefCell<Option<MaybeScope<'static>>> = Default::default();
-    }
-
-    struct RemoveScopeGuard;
-
-    impl Drop for RemoveScopeGuard {
-        fn drop(&mut self) {
-            SCOPE.set(None);
-        }
-    }
-
-    let mut scope = SCOPE.take().unwrap_or_default();
-
-    let (ra, rb) = join_maybe_scoped(
-        &mut scope,
-        |scope| {
-            let scope = unsafe {
-                // Safety: inner scope cannot outlive the outer scope
-                transmute::<Scope, Scope>(scope)
-            };
-            let _guard = RemoveScopeGuard;
-            SCOPE.set(Some(MaybeScope(ScopeLike::Scope(scope))));
-
-            oper_a()
-        },
-        |scope| {
-            let scope = unsafe {
-                // Safety: inner scope cannot outlive the outer scope
-                transmute::<Scope, Scope>(scope)
-            };
-            let _guard = RemoveScopeGuard;
-            SCOPE.set(Some(MaybeScope(ScopeLike::Scope(scope))));
-
-            oper_b()
-        },
-    );
-
-    // In case of panic, we does not restore the scope so it will be None.
-    SCOPE.set(Some(scope));
-
-    (ra, rb)
-}
-
-#[inline]
-pub fn join_maybe_scoped<'a, A, B, RA, RB>(
-    scope: &mut MaybeScope<'a>,
-    oper_a: A,
-    oper_b: B,
-) -> (RA, RB)
-where
-    A: Send + FnOnce(Scope<'a>) -> RA,
-    B: Send + FnOnce(Scope<'a>) -> RB,
-    RA: Send,
-    RB: Send,
-{
-    scope.with(|scope| join_scoped(scope, oper_a, oper_b))
-}
-
-#[inline]
-pub fn join_scoped<'a, A, B, RA, RB>(scope: Scope<'a>, oper_a: A, oper_b: B) -> (RA, RB)
-where
-    A: Send + FnOnce(Scope<'a>) -> RA,
-    B: Send + FnOnce(Scope<'a>) -> RB,
-    RA: Send,
-    RB: Send,
-{
     #[cfg(feature = "chili")]
-    let (ra, rb) = scope.0.join(
-        |scope| {
-            let scope = Scope(unsafe {
-                // Safety: This can be dangerous if the user do transmute on the scope, but it's
-                // not our fault if the user uses transmute.
-                transmute::<&mut chili::Scope, &mut chili::Scope>(scope)
-            });
-
-            oper_a(scope)
-        },
-        |scope| {
-            let scope = Scope(unsafe {
-                // Safety: This can be dangerous if the user do transmute on the scope, but it's
-                // not our fault if the user uses transmute.
-                transmute::<&mut chili::Scope, &mut chili::Scope>(scope)
-            });
-
-            oper_b(scope)
-        },
-    );
+    let (ra, rb) = par_chili::join(oper_a, oper_b);
 
     #[cfg(feature = "rayon")]
-    let (ra, rb) = rayon::join(
-        || oper_a(Scope(std::marker::PhantomData)),
-        || oper_b(Scope(std::marker::PhantomData)),
-    );
+    let (ra, rb) = rayon::join(oper_a, oper_b);
 
     #[cfg(not(feature = "parallel"))]
-    let (ra, rb) = (
-        oper_a(Scope(std::marker::PhantomData)),
-        oper_b(Scope(std::marker::PhantomData)),
-    );
+    let (ra, rb) = (oper_a(), oper_b());
 
     (ra, rb)
 }

--- a/crates/par-core/src/lib.rs
+++ b/crates/par-core/src/lib.rs
@@ -66,9 +66,9 @@ mod par_chili {
     }
 
     #[derive(Default)]
-    pub struct MaybeScope<'a>(ScopeLike<'a>);
+    struct MaybeScope<'a>(ScopeLike<'a>);
 
-    pub struct Scope<'a>(&'a mut chili::Scope<'a>);
+    struct Scope<'a>(&'a mut chili::Scope<'a>);
 
     enum ScopeLike<'a> {
         Scope(Scope<'a>),
@@ -83,7 +83,7 @@ mod par_chili {
 
     impl<'a> MaybeScope<'a> {
         #[allow(clippy::redundant_closure)]
-        pub fn with<F, R>(&mut self, f: F) -> R
+        fn with<F, R>(&mut self, f: F) -> R
         where
             F: FnOnce(Scope<'a>) -> R,
         {
@@ -114,7 +114,7 @@ mod par_chili {
     }
 
     #[inline]
-    pub fn join_maybe_scoped<'a, A, B, RA, RB>(
+    fn join_maybe_scoped<'a, A, B, RA, RB>(
         scope: &mut MaybeScope<'a>,
         oper_a: A,
         oper_b: B,
@@ -129,7 +129,7 @@ mod par_chili {
     }
 
     #[inline]
-    pub fn join_scoped<'a, A, B, RA, RB>(scope: Scope<'a>, oper_a: A, oper_b: B) -> (RA, RB)
+    fn join_scoped<'a, A, B, RA, RB>(scope: Scope<'a>, oper_a: A, oper_b: B) -> (RA, RB)
     where
         A: Send + FnOnce(Scope<'a>) -> RA,
         B: Send + FnOnce(Scope<'a>) -> RB,


### PR DESCRIPTION
closes https://github.com/swc-project/swc/issues/10453

I learnt that the basic idea of `par_core` is passing `&mut Scope` down by thread local variables. I think the original code is verbose and causes some bugs like https://github.com/swc-project/swc/issues/10453. So here I provide a simpler and more intuitive implementation.

Before:
<img width="701" alt="image" src="https://github.com/user-attachments/assets/1d692fd0-f601-4e2e-bfc9-d58b475991c6" />

After:
<img width="863" alt="image" src="https://github.com/user-attachments/assets/4bdb327a-cc1b-4834-87b3-c9be16bce623" />


Help me test if there's any bug (like panic) or performance regression.

This is a breaking change since I remove some public api (although I think they should not be public at all).
