### PR TITLE
chore: Fix cargo-mono publish command

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -155,4 +155,4 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
-          cargo mono publish --no-verify
+          cargo mono publish


### PR DESCRIPTION
## What changed

Removed the obsolete `--no-verify` flag from the `cargo mono publish` step in the publish workflow.

## Why

After updating to `cargo-mono@0.6.9`, the publish job failed because the new CLI no longer accepts `--no-verify`:

```text
error: unexpected argument '--no-verify' found
Usage: cargo mono publish [OPTIONS]
```

`cargo-mono 0.6.9` now documents that delegated Cargo verification remains disabled for the publish dry-run path, so the old flag is no longer needed.

## Validation

- Inspected the failed GitHub Actions job log from run `26939632822`, job `79478329256`.
- Confirmed `cargo mono publish --help` for `cargo-mono 0.6.9` no longer lists `--no-verify`.
- Ran `cargo mono publish --dry-run` successfully on a clean working tree.
- Ran `git diff --check HEAD~1..HEAD`.
