### PR TITLE
feat(is-macro): Don't include panic debug formatting in release builds

### DIFF
--- a/crates/is-macro/Cargo.toml
+++ b/crates/is-macro/Cargo.toml
@@ -11,6 +11,11 @@ version       = "0.3.7"
 [lib]
 proc-macro = true
 
+[features]
+# Omit Debug formatting of the value from `expect_*` panic messages in release
+# builds to reduce binary size.
+small-panic = []
+
 [dependencies]
 heck = { workspace = true }
 proc-macro2 = { workspace = true }

--- a/crates/is-macro/src/lib.rs
+++ b/crates/is-macro/src/lib.rs
@@ -248,7 +248,31 @@ fn expand(input: DataEnum) -> Vec<ImplItem> {
                 }
 
                 let variant = &v.ident;
-
+                let expect_panic_arm: syn::Arm = if cfg!(feature = "small-panic") {
+                    parse_quote!(
+                        _ => {
+                            // Omit Debug formatting in release builds to reduce binary size.
+                            #[cfg(debug_assertions)]
+                            panic!(
+                                concat!("called ", stringify!(#name_of_expect), " on {:?}"),
+                                self
+                            );
+                            #[cfg(not(debug_assertions))]
+                            panic!(concat!(
+                                "called ",
+                                stringify!(#name_of_expect),
+                                " on another variant",
+                            ));
+                        }
+                    )
+                } else {
+                    parse_quote!(
+                        _ => panic!(
+                            concat!("called ", stringify!(#name_of_expect), " on {:?}"),
+                            self
+                        )
+                    )
+                };
                 let item_impl: ItemImpl = parse_quote!(
                     impl #ty {
                         #[doc = #docs_of_cast]
@@ -277,24 +301,7 @@ fn expand(input: DataEnum) -> Vec<ImplItem> {
                         {
                             match self {
                                 Self::#variant(#fields) => (#fields),
-                                _ => {
-                                  // Keep debug formatting out of release builds to reduce binary size.
-                                  #[cfg(debug_assertions)]
-                                  panic!(
-                                      concat!(
-                                          "called ",
-                                          stringify!(#name_of_expect),
-                                          " on {:?}",
-                                      ),
-                                      self
-                                  );
-                                  #[cfg(not(debug_assertions))]
-                                  panic!(concat!(
-                                      "called ",
-                                      stringify!(#name_of_expect),
-                                      " on another variant",
-                                  ));
-                                },
+                                #expect_panic_arm
                             }
                         }
 

--- a/crates/is-macro/src/lib.rs
+++ b/crates/is-macro/src/lib.rs
@@ -203,8 +203,8 @@ fn expand(input: DataEnum) -> Vec<ImplItem> {
             );
             let docs_of_expect = format!(
                 "Unwraps the value, yielding the content of [`{variant}`].\n\n# Panics\n\nPanics \
-                 if the value is not [`{variant}`], with a panic message including the content of \
-                 `self`.\n\n[`{variant}`]: #variant.{variant}",
+                 if the value is not [`{variant}`]. In debug builds the panic message includes \
+                 the content of `self`.\n\n[`{variant}`]: #variant.{variant}",
                 variant = v.ident,
             );
             let docs_of_take = format!(
@@ -277,7 +277,24 @@ fn expand(input: DataEnum) -> Vec<ImplItem> {
                         {
                             match self {
                                 Self::#variant(#fields) => (#fields),
-                                _ => panic!("called expect on {:?}", self),
+                                _ => {
+                                  // Keep debug formatting out of release builds to reduce binary size.
+                                  #[cfg(debug_assertions)]
+                                  panic!(
+                                      concat!(
+                                          "called ",
+                                          stringify!(#name_of_expect),
+                                          " on {:?}",
+                                      ),
+                                      self
+                                  );
+                                  #[cfg(not(debug_assertions))]
+                                  panic!(concat!(
+                                      "called ",
+                                      stringify!(#name_of_expect),
+                                      " on another variant",
+                                  ));
+                                },
                             }
                         }
 


### PR DESCRIPTION
To reduce binary size, only include debug formatting in panic messages in debug `is-macro` builds, not release builds. In Parcel this reduced binary size by ~240KB by eliminating unused Debug implementations for the entire SWC AST.