### PR TITLE
chore: Bump is-macro to 0.3.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,7 +319,7 @@ dependencies = [
 
 [[package]]
 name = "is-macro"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/crates/is-macro/Cargo.toml
+++ b/crates/is-macro/Cargo.toml
@@ -6,7 +6,7 @@ edition       = "2018"
 license       = { workspace = true }
 name          = "is-macro"
 repository    = { workspace = true }
-version       = "0.3.7"
+version       = "0.3.8"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
## Summary

- Bump `is-macro` from `0.3.7` to `0.3.8`.
- Update the corresponding `Cargo.lock` package entry.

## Validation

- `cargo test -p is-macro`