### PR TITLE
ci: enable crates.io trusted publishing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -128,6 +128,10 @@ jobs:
   cargo-publish:
     name: "Publish"
     runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+      id-token: write
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs:
       - done
@@ -151,8 +155,12 @@ jobs:
         with:
           tool: cargo-mono@0.6.9
 
+      - name: Authenticate with crates.io
+        id: auth
+        uses: rust-lang/crates-io-auth-action@v1
+
       - name: Publish
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: |
-          cargo mono publish
+          cargo mono publish --max-attempts 10

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,9 +53,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arrayvec"
@@ -233,9 +233,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -524,9 +524,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.8.16"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3"
+checksum = "815cc8a37159a463064825246cadb07961e25cd9885908606f6d08a98d8f8874"
 dependencies = [
  "bytecheck",
  "bytes",
@@ -539,9 +539,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.8.16"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d2ed0b54125315fb36bd021e82d314d1c126548f871634b483f46b31d13cac6"
+checksum = "c0ed1a78a1b19d184b0daa629dd9a024573173ec7d485b287cb369fb3607cc1c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/dudykr/ddbase.git"
 
 [workspace.dependencies]
 Inflector                 = "0.11.4"
-anyhow                    = "1.0.98"
+anyhow                    = "1.0.103"
 arrayvec                  = "0.7.6"
 async-recursion           = "1.1.1"
 auto_impl                 = "1.3.0"
@@ -43,7 +43,7 @@ rand_xorshift             = "0.3"
 rayon                     = "1.10.0"
 regex                     = "1.11.1"
 reqwest                   = "0.12.15"
-rkyv                      = { version = "0.8.16", default-features = false, features = ["bytecheck"] }
+rkyv                      = { version = "0.8.17", default-features = false, features = ["bytecheck"] }
 rustc-hash                = "2.1.1"
 schemars                  = "0.8.22"
 scoped-tls                = "1"

--- a/crates/ddrpc-rt/Cargo.toml
+++ b/crates/ddrpc-rt/Cargo.toml
@@ -5,6 +5,7 @@ edition     = { workspace = true }
 include     = ["Cargo.toml", "src/**/*.rs"]
 license     = { workspace = true }
 name        = "ddrpc-rt"
+publish     = false
 repository  = { workspace = true }
 version     = "0.1.0"
 

--- a/crates/ddrpc/Cargo.toml
+++ b/crates/ddrpc/Cargo.toml
@@ -5,6 +5,7 @@ edition     = { workspace = true }
 include     = ["Cargo.toml", "src/**/*.rs"]
 license     = { workspace = true }
 name        = "ddrpc"
+publish     = false
 repository  = { workspace = true }
 version     = "0.1.0"
 


### PR DESCRIPTION
## Summary

- authenticate workspace publishing with crates.io Trusted Publishing and GitHub OIDC
- update dependencies affected by current RustSec advisories
- mark the unpublished ddrpc crates as non-publishable
- bound cargo-mono publish retries

## External setup

- created the GitHub release environment with a main-only deployment branch policy
- registered dudykr/ddbase, CI.yml, and release as a Trusted Publisher for all 12 existing public workspace crates
- left existing crates.io API-token publishing enabled

## Validation

- cargo fmt --all -- --check
- cargo deny check
- cargo clippy --all --all-targets -- -D warnings
- cargo test --all
- cargo check --all --all-targets
- cargo mono publish --dry-run --max-attempts 1

The publish dry-run selected only is-macro 0.3.8, skipped ddrpc and ddrpc-rt as non-publishable, and skipped the other workspace crates as already published.